### PR TITLE
require attribution model by default.

### DIFF
--- a/attribution.gemspec
+++ b/attribution.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "activesupport"
   gem.add_runtime_dependency "tzinfo"
   gem.add_development_dependency "activemodel"
+  gem.add_development_dependency "mocha"
 end

--- a/lib/attribution.rb
+++ b/lib/attribution.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext'
 require 'attribution/util'
 require 'attribution/version'
+require 'attribution/model'
 
 module Attribution
   BOOLEAN_TRUE_STRINGS = ['y','yes','t','true']

--- a/lib/attribution/version.rb
+++ b/lib/attribution/version.rb
@@ -1,3 +1,3 @@
 module Attribution
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
Add mocha to gem spec development dependencies.
